### PR TITLE
Retirando coluna firstLogin que não era utilizada

### DIFF
--- a/seeders/cria_admin_ini.cjs
+++ b/seeders/cria_admin_ini.cjs
@@ -22,7 +22,6 @@ module.exports = {
           idRole: 5,
           createdAt: new Date(),
           updatedAt: new Date(),
-          firstLogin: true,
         },
         {
           cpf: '12345678909',
@@ -34,7 +33,6 @@ module.exports = {
           idRole: 1,
           createdAt: new Date(),
           updatedAt: new Date(),
-          firstLogin: true,
         },
       ],
       {},

--- a/src/migrations/001-CreateUser.cjs
+++ b/src/migrations/001-CreateUser.cjs
@@ -34,10 +34,6 @@ module.exports = {
         type: Sequelize.INTEGER,
         allowNull: false,
       },
-      firstLogin: {
-        type: Sequelize.BOOLEAN,
-        allowNull: false,
-      },
       createdAt: {
         type: Sequelize.DATE,
         allowNull: false,


### PR DESCRIPTION
## Issue

Existia uma coluna que não era utilizada pelo sistema e que era necessário remover manualmente toda vez que o banco de dados era migrado. Por isso é necessário retirar ela das migrations

Closes fga-eps-mds/2023-2-CAPJu-Doc#176


